### PR TITLE
fix(ApiCall): prevent ML-CLI from generating null results for api call

### DIFF
--- a/src/Ecotag/ClientApp/src/Local/FileTreatment/FileTreatment.js
+++ b/src/Ecotag/ClientApp/src/Local/FileTreatment/FileTreatment.js
@@ -81,41 +81,48 @@ try {
         }
     ];
 
-    const mapItems = data => (data.map(item => {
-        if (item.Left == null || item.Right == null) {
-            return;
-        }
-        return {
-            fileName: item.FileName,
-            left: {
-                Url: item.Left.Url,
-                FileName: item.Left.FileName,
-                FileDirectory: item.Left.FileDirectory,
-                ImageDirectory: item.Left.ImageDirectory,
-                FrontDefaultStringsMatcher: item.Left.FrontDefaultStringsMatcher,
-                StatusCode: item.Left.StatusCode,
-                Body: item.Left.Body,
-                Headers: item.Left.Headers,
-                TimeMs: item.Left.TimeMs,
-                TicksAt: item.Left.TicksAt
-            },
-            right: {
-                Url: item.Right.Url,
-                FileName: item.Right.FileName,
-                FileDirectory: item.Right.FileDirectory,
-                ImageDirectory: item.Right.ImageDirectory,
-                FrontDefaultStringsMatcher: item.Right.FrontDefaultStringsMatcher,
-                StatusCode: item.Right.StatusCode,
-                Body: item.Right.Body,
-                Headers: item.Right.Headers,
-                TimeMs: item.Right.TimeMs,
-                TicksAt: item.Right.TicksAt
-            },
-            id: cuid(),
-            parse: false,
-            collapse: true,
-        };
-    }));
+    const mapItems = data => {
+        const mappedItems = data.map(item => {
+            if (!item || !item.Left || !item.Right) {
+                if(item){
+                    console.log("File " + item.FileName + " does not contain the required data, and will be ignored. Please investigate on this file.");
+                    console.log(item);
+                }
+                return;
+            }
+            return {
+                fileName: item.FileName,
+                left: {
+                    Url: item.Left.Url,
+                    FileName: item.Left.FileName,
+                    FileDirectory: item.Left.FileDirectory,
+                    ImageDirectory: item.Left.ImageDirectory,
+                    FrontDefaultStringsMatcher: item.Left.FrontDefaultStringsMatcher,
+                    StatusCode: item.Left.StatusCode,
+                    Body: item.Left.Body,
+                    Headers: item.Left.Headers,
+                    TimeMs: item.Left.TimeMs,
+                    TicksAt: item.Left.TicksAt
+                },
+                right: {
+                    Url: item.Right.Url,
+                    FileName: item.Right.FileName,
+                    FileDirectory: item.Right.FileDirectory,
+                    ImageDirectory: item.Right.ImageDirectory,
+                    FrontDefaultStringsMatcher: item.Right.FrontDefaultStringsMatcher,
+                    StatusCode: item.Right.StatusCode,
+                    Body: item.Right.Body,
+                    Headers: item.Right.Headers,
+                    TimeMs: item.Right.TimeMs,
+                    TicksAt: item.Right.TicksAt
+                },
+                id: cuid(),
+                parse: false,
+                collapse: true,
+            };
+        });
+        return mappedItems.filter(item => item !== undefined && item !== null);
+    }
 
     const compareStatusCode = (status, result) => {
         const strStatus = status.toString();
@@ -138,23 +145,21 @@ try {
     };
 
     const onLoad = (result, fileName) => {
-        const isVersion0 = Array.isArray(result);
-        if (!result.hasOwnProperty('CompareLocation')) {
+        if(!result || !Array.isArray(result.Content) || !result.CompareLocation){
             onLoadFailure(fileName);
-        } else {
-            const location = isVersion0 ? "" : result.CompareLocation;
-            const mappedItems = mapItems(isVersion0 ? result : result.Content);
-            const statusCodeItems = setStatusFilterItems(mappedItems);
-            setState
-            ({
-                ...state,
-                fileName: fileName,
-                compareLocation: location,
-                items: mappedItems,
-                statusCodes: statusCodeItems
-            });
-            setFilterState({...filterState, loadFileError: false});
         }
+        const location = result.CompareLocation;
+        const mappedItems = mapItems(result.Content);
+        const statusCodeItems = setStatusFilterItems(mappedItems);
+        setState
+        ({
+            ...state,
+            fileName: fileName,
+            compareLocation: location,
+            items: mappedItems,
+            statusCodes: statusCodeItems
+        });
+        setFilterState({...filterState, loadFileError: false});
     };
 
     const onLoadFailure = fileName => {

--- a/src/Ecotag/ClientApp/src/Local/FileTreatment/FileTreatment.js
+++ b/src/Ecotag/ClientApp/src/Local/FileTreatment/FileTreatment.js
@@ -33,8 +33,80 @@ const timeSideVariables = [
     {value: 'Right', label: 'Right'}
 ];
 
-const FileTreatment = ({state, setState, MonacoEditor, fetch}) => {
+const checkboxOptions = [
+    {
+        key: "checkbox_isAnnotationOpen",
+        id: "is_annotation_open_checkbox",
+        value: "test",
+        label: "Is annotation open ? ",
+        disabled: false
+    }
+];
 
+export const mapItems = data => {
+    const mappedItems = data.map(item => {
+        if (!item || !item.Left || !item.Right) {
+            if(item){
+                console.log("File " + item.FileName + " does not contain the required data, and will be ignored. Please investigate on this file.");
+                console.log(item);
+            }
+            return;
+        }
+        return {
+            fileName: item.FileName,
+            left: {
+                Url: item.Left.Url,
+                FileName: item.Left.FileName,
+                FileDirectory: item.Left.FileDirectory,
+                ImageDirectory: item.Left.ImageDirectory,
+                FrontDefaultStringsMatcher: item.Left.FrontDefaultStringsMatcher,
+                StatusCode: item.Left.StatusCode,
+                Body: item.Left.Body,
+                Headers: item.Left.Headers,
+                TimeMs: item.Left.TimeMs,
+                TicksAt: item.Left.TicksAt
+            },
+            right: {
+                Url: item.Right.Url,
+                FileName: item.Right.FileName,
+                FileDirectory: item.Right.FileDirectory,
+                ImageDirectory: item.Right.ImageDirectory,
+                FrontDefaultStringsMatcher: item.Right.FrontDefaultStringsMatcher,
+                StatusCode: item.Right.StatusCode,
+                Body: item.Right.Body,
+                Headers: item.Right.Headers,
+                TimeMs: item.Right.TimeMs,
+                TicksAt: item.Right.TicksAt
+            },
+            id: cuid(),
+            parse: false,
+            collapse: true,
+        };
+    });
+    return mappedItems.filter(item => item !== undefined && item !== null);
+};
+
+export const compareStatusCode = (status, result) => {
+    const strStatus = status.toString();
+    const index = result.findIndex(element => element.value === strStatus);
+    if (index !== -1) {
+        return;
+    }
+    const newItem = {value: strStatus, label: strStatus};
+    result.push(newItem);
+};
+
+export const setStatusFilterItems = newItems => {
+    const allCodes = {value: "All", label: "All"};
+    const result = [allCodes];
+    newItems.forEach(item => {
+        compareStatusCode(item.left.StatusCode, result);
+        compareStatusCode(item.right.StatusCode, result);
+    });
+    return result;
+};
+
+const FileTreatment = ({state, setState, MonacoEditor, fetch}) => {
     const [filterState, setFilterState] = useState({
         filterName: "KO",
         extensionName: "All",
@@ -70,79 +142,6 @@ try {
     rawBodyOutput = rawBodyInput;
 }`
     });
-
-    const checkboxOptions = [
-        {
-            key: "checkbox_isAnnotationOpen",
-            id: "is_annotation_open_checkbox",
-            value: "test",
-            label: "Is annotation open ? ",
-            disabled: false
-        }
-    ];
-
-    const mapItems = data => {
-        const mappedItems = data.map(item => {
-            if (!item || !item.Left || !item.Right) {
-                if(item){
-                    console.log("File " + item.FileName + " does not contain the required data, and will be ignored. Please investigate on this file.");
-                    console.log(item);
-                }
-                return;
-            }
-            return {
-                fileName: item.FileName,
-                left: {
-                    Url: item.Left.Url,
-                    FileName: item.Left.FileName,
-                    FileDirectory: item.Left.FileDirectory,
-                    ImageDirectory: item.Left.ImageDirectory,
-                    FrontDefaultStringsMatcher: item.Left.FrontDefaultStringsMatcher,
-                    StatusCode: item.Left.StatusCode,
-                    Body: item.Left.Body,
-                    Headers: item.Left.Headers,
-                    TimeMs: item.Left.TimeMs,
-                    TicksAt: item.Left.TicksAt
-                },
-                right: {
-                    Url: item.Right.Url,
-                    FileName: item.Right.FileName,
-                    FileDirectory: item.Right.FileDirectory,
-                    ImageDirectory: item.Right.ImageDirectory,
-                    FrontDefaultStringsMatcher: item.Right.FrontDefaultStringsMatcher,
-                    StatusCode: item.Right.StatusCode,
-                    Body: item.Right.Body,
-                    Headers: item.Right.Headers,
-                    TimeMs: item.Right.TimeMs,
-                    TicksAt: item.Right.TicksAt
-                },
-                id: cuid(),
-                parse: false,
-                collapse: true,
-            };
-        });
-        return mappedItems.filter(item => item !== undefined && item !== null);
-    }
-
-    const compareStatusCode = (status, result) => {
-        const strStatus = status.toString();
-        const index = result.findIndex(element => element.value === strStatus);
-        if (index !== -1) {
-            return;
-        }
-        const newItem = {value: strStatus, label: strStatus};
-        result.push(newItem);
-    };
-
-    const setStatusFilterItems = newItems => {
-        const allCodes = {value: "All", label: "All"};
-        const result = [allCodes];
-        newItems.forEach(item => {
-            compareStatusCode(item.left.StatusCode, result);
-            compareStatusCode(item.right.StatusCode, result);
-        });
-        return result;
-    };
 
     const onLoad = (result, fileName) => {
         if(!result || !Array.isArray(result.Content) || !result.CompareLocation){

--- a/src/Ecotag/ClientApp/src/Local/FileTreatment/FileTreatment.spec.js
+++ b/src/Ecotag/ClientApp/src/Local/FileTreatment/FileTreatment.spec.js
@@ -1,0 +1,105 @@
+import {compareStatusCode, mapItems, setStatusFilterItems,} from './FileTreatment';
+
+describe('Check file treatment', () => {
+    it('should map items properly', () => {
+        const data = [
+            {
+                FileName: "MyFirstFileName.txt",
+                Left: {
+                    Url: "http://localhost:5000",
+                    FileName: "MyFirstFileName.txt",
+                    FileDirectory: "folder1",
+                    ImageDirectory: "folder2",
+                    FrontDefaultStringsMatcher: "",
+                    StatusCode: 200,
+                    Body: "Blah blah blah",
+                    Headers: "",
+                    TimeMs: 4000,
+                    TicksAt: 0
+                },
+                Right: {
+                    Url: "http://localhost:5000",
+                    FileName: "MyFirstFileName.txt",
+                    FileDirectory: "folder1",
+                    ImageDirectory: "folder2",
+                    FrontDefaultStringsMatcher: "",
+                    StatusCode: 400,
+                    Body: "Blah blah blah",
+                    Headers: "",
+                    TimeMs: 4000,
+                    TicksAt: 0
+                }
+            },
+            undefined,
+            {
+                FileName: "MySecondFileName.txt",
+                Left: {
+                    Url: "http://localhost:5000",
+                    FileName: "MySecondFileName.txt",
+                    FileDirectory: "folder1",
+                    ImageDirectory: "folder2",
+                    FrontDefaultStringsMatcher: "",
+                    StatusCode: 200,
+                    Body: "Blah blah blah",
+                    Headers: "",
+                    TimeMs: 4000,
+                    TicksAt: 0
+                },
+                Right: {
+                    Url: "http://localhost:5000",
+                    FileName: "MySecondFileName.txt",
+                    FileDirectory: "folder1",
+                    ImageDirectory: "folder2",
+                    FrontDefaultStringsMatcher: "",
+                    StatusCode: 400,
+                    Body: "Blah blah blah",
+                    Headers: "",
+                    TimeMs: 4000,
+                    TicksAt: 0
+                }
+            },
+            null
+        ];
+        const mappedData = mapItems(data);
+        expect(mappedData.length).toEqual(2);
+        for(let item in mappedData){
+            expect(item).not.toBeUndefined();
+            expect(item).not.toBeNull();
+        }
+    });
+    it('should add new status code properly', () => {
+        const statusCode = 200;
+        const result = [{value: "All", label: "All"}];
+        compareStatusCode(statusCode, result);
+
+        expect(result.length).toEqual(2);
+        expect(result[0]).toEqual({value: "All", label: "All"});
+        expect(result[1]).toEqual({value: "200", label: "200"});
+    });
+    it('should set status filter items properly', () => {
+        const items = [
+            {
+                left: {
+                    StatusCode: 200
+                },
+                right: {
+                    StatusCode: 200
+                }
+            },
+            {
+                left: {
+                    StatusCode: 200
+                },
+                right: {
+                    StatusCode: 400
+                }
+            }
+        ];
+        const newFilters = setStatusFilterItems(items);
+
+        expect(newFilters.length).toEqual(3);
+        expect(newFilters[0]).toEqual({value: "All", label: "All"});
+        expect(newFilters[1]).toEqual({value: "200", label: "200"});
+        expect(newFilters[2]).toEqual({value: "400", label: "400"});
+    });
+});

--- a/src/MlCli/JobApiCall/Job.cs
+++ b/src/MlCli/JobApiCall/Job.cs
@@ -108,10 +108,10 @@ public class TaskApiCall
                             numberKo += 1;
                             _logger.LogWarning("number KO: " + numberKo + "/" + (indexFile + 1));
                         }
-                        else if (task.Result == "Exception")
+                        else if (task.IsFaulted)
                         {
                             numberExceptions += 1;
-                            _logger.LogWarning("number exceptions: " + numberExceptions + "/" + (indexFile + 1));
+                            _logger.LogWarning($"number exceptions: {numberExceptions}/{indexFile + 1}");
                         }
 
                         tasksToRemove.Add(task);

--- a/src/MlCli/JobApiCall/Job.cs
+++ b/src/MlCli/JobApiCall/Job.cs
@@ -70,10 +70,10 @@ public class TaskApiCall
             var numberChunk = inputTask.ChunkByNumberPart.Value;
             var chunkIndex = inputTask.ChunkIndex.Value;
             var d = files.Count / (decimal)numberChunk;
-            var numberfilesbychunck = d > files.Count / numberChunk
+            var numberFilesByChunk = d > files.Count / numberChunk
                 ? files.Count / numberChunk + 1
                 : files.Count / numberChunk;
-            var listsOfFiles = ChunkBy(files.ToList(), numberfilesbychunck);
+            var listsOfFiles = ChunkBy(files.ToList(), numberFilesByChunk);
             files = listsOfFiles[chunkIndex];
         }
 
@@ -87,6 +87,7 @@ public class TaskApiCall
             var indexFile = 0;
             var indexFileFetched = 0;
             var numberKo = 0;
+            var numberExceptions = 0;
             while (indexFile < numberFiles)
             {
                 while (tasks.Count < inputTask.NumberParallel && indexFile < numberFiles)
@@ -107,6 +108,11 @@ public class TaskApiCall
                             numberKo += 1;
                             _logger.LogWarning("number KO: " + numberKo + "/" + (indexFile + 1));
                         }
+                        else if (task.Result == "Exception")
+                        {
+                            numberExceptions += 1;
+                            _logger.LogWarning("number exceptions: " + numberExceptions + "/" + (indexFile + 1));
+                        }
 
                         tasksToRemove.Add(task);
                     }
@@ -126,13 +132,12 @@ public class TaskApiCall
         string extension, string outputDirectory)
     {
         if (Path.GetExtension(currentFilePath) == ".json") return string.Empty;
-
         
         var jsonFileName = GetTargetFileName(inputTask.IsDefaultTargetFileMode, currentFilePath, extension);
         var targetFileName = Path.Combine(outputDirectory, jsonFileName);
+        var fileName = Path.GetFileName(currentFilePath);
         try
         {
-            var fileName = Path.GetFileName(currentFilePath);
             if (_fileLoader.FileExists(targetFileName))
             {
                 _logger.LogWarning($"Task Id: {inputTask.Id} - Already processed file {fileName}");
@@ -148,7 +153,25 @@ public class TaskApiCall
                 try
                 {
                     httpResult = await CallHttpAsync(httpClient, inputTask, currentFilePath, jsonFileName, i);
-                    if (httpResult.StatusCode < 500) break;
+                    if (httpResult == null)
+                    {
+                        httpResult = new Program.HttpResult
+                        {
+                            FileName = fileName,
+                            FileDirectory = Path.Combine(inputTask.OutputDirectoryJsons, targetFileName),
+                            ImageDirectory = inputTask.OutputDirectoryImages,
+                            FrontDefaultStringsMatcher = inputTask.FrontDefaultStringsMatcher,
+                            StatusCode = 600,
+                            Body = $"Task Id: {inputTask.Id} - Error : http result is null",
+                            Headers = new List<KeyValuePair<string, IEnumerable<string>>>(),
+                            TimeMs = 0,
+                            Url = inputTask.Url,
+                            TicksAt = DateTime.UtcNow.Ticks,
+                            TryNumber = i
+                        };
+                        _logger.LogError($"Task Id: {inputTask.Id} - Error : http result is null");
+                    }
+                    else if (httpResult.StatusCode < 500) break;
                 }
                 catch (Exception e)
                 {
@@ -171,9 +194,6 @@ public class TaskApiCall
 
                 if (i < inputTask.NumberRetryOnHttp500 + 1) await Task.Delay(inputTask.DelayOn500);
             }
-
-            if (httpResult == null)
-                throw new ApplicationException("httpResult is null");
 
             if (httpResult.StatusCode >= 500 && (!inputTask.IsSaveResultOnError || httpResult.StatusCode < 500))
                 return httpResult.StatusCode < 500 ? "OK" : "KO";


### PR DESCRIPTION
This pull request is a fix to the following problem :
Providing a compare file to ML-CLI webapp, when the Left or Right of a dataset file is null, will result in a crash. As shown in the unique commit, this is due to the fact that the mapping of the dataset files data does not remove undefined or null items.
To solve this problem, I added a filter on the mapped data to remove undefined and null items, and I also updated JobApiCall to reduce the risk of having this situation. It can still occur if the writing of the http result in a file fails, but this is an exceptionnal case and will be handled by the new mapping security.